### PR TITLE
Modify: OTP 등록 유무에 따른 로직 수정

### DIFF
--- a/frontend/srcs/js/app.js
+++ b/frontend/srcs/js/app.js
@@ -1,19 +1,23 @@
 //import './utils/renderPage.js';
 import {fetchTokens, checkaccess} from './utils/checkToken.js'
 import globalState, { resetGlobalState } from './globalState.js'; 
-
 import { Router } from './router.js';
+import { checkOTP } from './utils/api.js'
 
 async function handleLogin(router) {
   let isLoggedIn = await checkaccess();
-  if (isLoggedIn && globalState.otp == true) {
+  let hasOTP = await checkOTP();
+  if (isLoggedIn && hasOTP === true) {
     globalState.intraID = localStorage.getItem('spacePongIntraID');
   } else {
     await fetchTokens(router);
     isLoggedIn = await checkaccess();
-    if (!isLoggedIn)
-    {
+    if (!isLoggedIn) {
       await router.navigateTo("/login");
+    }
+    hasOTP = await checkOTP();
+    if (isLoggedIn && !hasOTP) {
+      await router.navigateTo("/otp");
     }
   }
 }

--- a/frontend/srcs/js/router.js
+++ b/frontend/srcs/js/router.js
@@ -13,7 +13,7 @@ import {fetchTokens, checkaccess} from './utils/checkToken.js'
 import globalState, { resetGlobalState } from './globalState.js';
 import { renderLogin } from './utils/renderLogin.js';
 import { otpPage } from './pages/otpPage.js';
-import { getData, postData, deleteData } from './utils/api.js'
+import { getData, postData, deleteData, checkOTP } from './utils/api.js'
 
 export class Router {
   constructor() {
@@ -84,6 +84,12 @@ export class Router {
         window.location.pathname !== '/otp' &&
         window.location.pathname !== '/' &&
         globalState.intraID === null) {
+      resetGlobalState();
+      window.location.pathname = '/login';
+    }
+    const hasOTP = await checkOTP();
+    if (globalState.intraID !== null &&
+      hasOTP === false) {
       resetGlobalState();
       window.location.pathname = '/login';
     }

--- a/frontend/srcs/js/utils/api.js
+++ b/frontend/srcs/js/utils/api.js
@@ -34,7 +34,7 @@ export async function postData(skin) {
     body: JSON.stringify(data),
   });
   if (!response.ok) {
-    console.error('Error fetching data:');
+    console.error('Error post data:');
     return;
   }
   return response.json();
@@ -55,8 +55,45 @@ export async function deleteData(type) {
     body: JSON.stringify(data),
   });
   if (!response.ok) {
-    console.error('Error fetching data:');
+    console.error('Error delete data:');
     return;
   }
   return response.json();
+}
+
+export async function checkOTP() {
+  await checkaccess()
+  const token = localStorage.getItem('accessToken');
+  const response = await fetch('twofactor/auth/', {
+    method: 'GET',
+    headers: {
+      "Content-Type": "application/json",
+      'Authorization': 'Bearer ' + token
+    },
+  });
+  if (!response.ok) {
+    console.error('Error check OTP data:');
+    return;
+  }
+  const data = await response.json();
+  if (data === "success") {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+export async function registerOTP() {
+  await checkaccess()
+  const token = localStorage.getItem('accessToken');
+  const response = await fetch('twofactor/auth/', {
+    method: 'POST',
+    headers: {
+      "Content-Type": "application/json",
+      'Authorization': 'Bearer ' + token
+    }
+  });
+  if (!response.ok) {
+    console.error('Error post OTP data:');
+  }
 }

--- a/frontend/srcs/js/utils/otpUtil.js
+++ b/frontend/srcs/js/utils/otpUtil.js
@@ -1,5 +1,6 @@
 import globalState from '../globalState.js';
 import { Router } from '../router.js';
+import { registerOTP } from '../utils/api.js'
 
 export function otpUtil(router) {
     document.querySelector('#otpInput').focus();
@@ -14,7 +15,6 @@ export function otpUtil(router) {
         const OTP_num = document.querySelector('#otpInput').value.trim();
         if (OTP_num)
         {
-            // console.log("I have otp num!");
             const token = localStorage.getItem('accessToken');
             try {
                 const response = await fetch(`twofactor/mail/?OTP=${OTP_num}`, {
@@ -30,10 +30,8 @@ export function otpUtil(router) {
                 }
                 const data = await response.json();
                 if (data === "OTP OK") {
-                    globalState.otp = true;
-                    // console.log("otp ok : ", globalState.otp);
+                    registerOTP();
                     await router.navigateTo("/");
-                    // window.location.pathname = "/";
                 } else {
                     alert("OTP authentication failed");
                 }


### PR DESCRIPTION
- 로그인 또는 OTP 등록 시간(1시간) 만료시, OTP 페이지로 이동하여 갱신하도록 수정.
- 이미 로그인이 되어 있고 OTP도 등록 되어 있는 경우, OTP 인증 생략.
- OTP 인증 기록 및 관리는 Backend에서 처리.
- Frontend는 Backend와 API(twofactor/auth/)를 통해 OTP 갱신 및 상태 확인.